### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "##[set-output name=VERSION;]$(echo ${GITHUB_REF#refs/tags/})"
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: metaheed/kolle-ci
           tags: "latest,${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore